### PR TITLE
Remove unnecessary print statement

### DIFF
--- a/src/timestream_query/QueryUtil.py
+++ b/src/timestream_query/QueryUtil.py
@@ -33,8 +33,8 @@ class QueryUtil:
     def __parse_query_result(self, query_result, obj=False):
         column_info = query_result["ColumnInfo"]
 
-        # print("Metadata: %s" % column_info)
-        print("Data: ")
+        print("Metadata: %s" % column_info)
+#         print("Data: ")
         data = []
         for row in query_result["Rows"]:
             if obj == True:


### PR DESCRIPTION
At the moment this prints "Data:" which makes it looks like there should be something else there. Without any extra info, there's not much use in this statement other than to show something is happening.

I suggest either reinstating the earlier print statement, or if this is too verbose, then either truncate that somehow or don't print anything.